### PR TITLE
Add LoadData project for load synchronization

### DIFF
--- a/CSIxRevit.sln
+++ b/CSIxRevit.sln
@@ -15,6 +15,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReinforcementFromEtab", "Re
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StructLink_X", "StructLink_X\StructLink_X.csproj", "{C28FE4E9-9C5C-A191-1E0C-2E2E20319289}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LoadData", "LoadDatas\LoadData.csproj", "{1A6C234C-007E-43FB-AAF4-085977A4219A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,6 +47,10 @@ Global
 		{C28FE4E9-9C5C-A191-1E0C-2E2E20319289}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C28FE4E9-9C5C-A191-1E0C-2E2E20319289}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C28FE4E9-9C5C-A191-1E0C-2E2E20319289}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1A6C234C-007E-43FB-AAF4-085977A4219A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1A6C234C-007E-43FB-AAF4-085977A4219A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1A6C234C-007E-43FB-AAF4-085977A4219A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1A6C234C-007E-43FB-AAF4-085977A4219A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/FromRevit/FromRevit.csproj
+++ b/FromRevit/FromRevit.csproj
@@ -17,6 +17,7 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\ElementsData\ElementsData.csproj" />
+		<ProjectReference Include="..\LoadDatas\LoadData.csproj" />
 		<ProjectReference Include="..\Styles\Styles.csproj" />
 	</ItemGroup>
 

--- a/FromRevit/Loads.cs
+++ b/FromRevit/Loads.cs
@@ -1,0 +1,486 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Autodesk.Revit.DB;
+using CSIXRevit.LoadData;
+
+namespace CSIXRevit.FromRevit
+{
+    public class Loads
+    {
+        public static List<LoadAssignment> GetLoadData(Document doc)
+        {
+            List<LoadAssignment> loads = new List<LoadAssignment>();
+
+            ExtractPointLoads(doc, loads);
+            ExtractLineLoads(doc, loads);
+            ExtractAreaLoads(doc, loads);
+
+            return loads;
+        }
+
+        private static void ExtractPointLoads(Document doc, List<LoadAssignment> loads)
+        {
+            FilteredElementCollector collector = new FilteredElementCollector(doc)
+                .OfCategory(BuiltInCategory.OST_PointLoads)
+                .WhereElementIsNotElementType();
+
+            foreach (Element elem in collector)
+            {
+                ElementId hostId = null;
+
+                Parameter hostParam = elem.LookupParameter("Host");
+                if (hostParam != null && hostParam.HasValue && hostParam.StorageType == StorageType.ElementId)
+                {
+                    hostId = hostParam.AsElementId();
+                }
+
+                if (hostId == null || hostId == ElementId.InvalidElementId)
+                {
+                    foreach (ElementId id in elem.GetDependentElements(null))
+                    {
+                        Element possibleHost = doc.GetElement(id);
+                        if (possibleHost != null &&
+                            (possibleHost.Category.Id.IntegerValue == (int)BuiltInCategory.OST_StructuralFraming ||
+                             possibleHost.Category.Id.IntegerValue == (int)BuiltInCategory.OST_StructuralColumns))
+                        {
+                            hostId = id;
+                            break;
+                        }
+                    }
+                }
+
+                if (hostId == null || hostId == ElementId.InvalidElementId) continue;
+
+                Element host = doc.GetElement(hostId);
+                if (host == null) continue;
+
+                Parameter forceX = elem.LookupParameter("Force X");
+                Parameter forceY = elem.LookupParameter("Force Y");
+                Parameter forceZ = elem.LookupParameter("Force Z");
+
+                Parameter loadCase = elem.LookupParameter("Load Case");
+                string loadCaseName = loadCase?.AsValueString() ?? "DEAD";
+
+                if (forceX != null && Math.Abs(forceX.AsDouble()) > 0.001)
+                {
+                    loads.Add(new LoadAssignment
+                    {
+                        ElementID = host.UniqueId,
+                        LoadPattern = loadCaseName,
+                        LoadType = "PointLoad",
+                        Value = forceX.AsDouble(),
+                        Unit = "N",
+                        Dir = 0,
+                        SourcePlatform = "Revit",
+                        LastModified = DateTime.Now,
+                        SyncState = LoadSyncState.New
+                    });
+                }
+
+                if (forceY != null && Math.Abs(forceY.AsDouble()) > 0.001)
+                {
+                    loads.Add(new LoadAssignment
+                    {
+                        ElementID = host.UniqueId,
+                        LoadPattern = loadCaseName,
+                        LoadType = "PointLoad",
+                        Value = forceY.AsDouble(),
+                        Unit = "N",
+                        Dir = 1,
+                        SourcePlatform = "Revit",
+                        LastModified = DateTime.Now,
+                        SyncState = LoadSyncState.New
+                    });
+                }
+
+                if (forceZ != null && Math.Abs(forceZ.AsDouble()) > 0.001)
+                {
+                    loads.Add(new LoadAssignment
+                    {
+                        ElementID = host.UniqueId,
+                        LoadPattern = loadCaseName,
+                        LoadType = "PointLoad",
+                        Value = forceZ.AsDouble(),
+                        Unit = "N",
+                        Dir = 2,
+                        SourcePlatform = "Revit",
+                        LastModified = DateTime.Now,
+                        SyncState = LoadSyncState.New
+                    });
+                }
+
+                Parameter momentX = elem.LookupParameter("Moment X");
+                Parameter momentY = elem.LookupParameter("Moment Y");
+                Parameter momentZ = elem.LookupParameter("Moment Z");
+
+                if (momentX != null && Math.Abs(momentX.AsDouble()) > 0.001)
+                {
+                    loads.Add(new LoadAssignment
+                    {
+                        ElementID = host.UniqueId,
+                        LoadPattern = loadCaseName,
+                        LoadType = "MomentLoad",
+                        Value = momentX.AsDouble(),
+                        Unit = "N-m",
+                        Dir = 0,
+                        SourcePlatform = "Revit",
+                        LastModified = DateTime.Now,
+                        SyncState = LoadSyncState.New
+                    });
+                }
+
+                if (momentY != null && Math.Abs(momentY.AsDouble()) > 0.001)
+                {
+                    loads.Add(new LoadAssignment
+                    {
+                        ElementID = host.UniqueId,
+                        LoadPattern = loadCaseName,
+                        LoadType = "MomentLoad",
+                        Value = momentY.AsDouble(),
+                        Unit = "N-m",
+                        Dir = 1,
+                        SourcePlatform = "Revit",
+                        LastModified = DateTime.Now,
+                        SyncState = LoadSyncState.New
+                    });
+                }
+
+                if (momentZ != null && Math.Abs(momentZ.AsDouble()) > 0.001)
+                {
+                    loads.Add(new LoadAssignment
+                    {
+                        ElementID = host.UniqueId,
+                        LoadPattern = loadCaseName,
+                        LoadType = "MomentLoad",
+                        Value = momentZ.AsDouble(),
+                        Unit = "N-m",
+                        Dir = 2,
+                        SourcePlatform = "Revit",
+                        LastModified = DateTime.Now,
+                        SyncState = LoadSyncState.New
+                    });
+                }
+            }
+        }
+
+        private static void ExtractLineLoads(Document doc, List<LoadAssignment> loads)
+        {
+            FilteredElementCollector collector = new FilteredElementCollector(doc)
+                .OfCategory(BuiltInCategory.OST_LineLoads)
+                .WhereElementIsNotElementType();
+
+            foreach (Element elem in collector)
+            {
+                ElementId hostId = null;
+
+                Parameter hostParam = elem.LookupParameter("Host");
+                if (hostParam != null && hostParam.HasValue && hostParam.StorageType == StorageType.ElementId)
+                {
+                    hostId = hostParam.AsElementId();
+                }
+
+                if (hostId == null || hostId == ElementId.InvalidElementId)
+                {
+                    foreach (ElementId id in elem.GetDependentElements(null))
+                    {
+                        Element possibleHost = doc.GetElement(id);
+                        if (possibleHost != null &&
+                            possibleHost.Category.Id.IntegerValue == (int)BuiltInCategory.OST_StructuralFraming)
+                        {
+                            hostId = id;
+                            break;
+                        }
+                    }
+                }
+
+                if (hostId == null || hostId == ElementId.InvalidElementId) continue;
+
+                Element host = doc.GetElement(hostId);
+                if (host == null) continue;
+
+                Parameter forceX = elem.LookupParameter("Force X");
+                Parameter forceY = elem.LookupParameter("Force Y");
+                Parameter forceZ = elem.LookupParameter("Force Z");
+
+                Parameter loadCase = elem.LookupParameter("Load Case");
+                string loadCaseName = loadCase?.AsValueString() ?? "DEAD";
+
+                double startDistance = 0.0;
+                double endDistance = 1.0;
+
+                Parameter startParam = elem.LookupParameter("Start Parameter");
+                Parameter endParam = elem.LookupParameter("End Parameter");
+
+                if (startParam != null && endParam != null)
+                {
+                    startDistance = startParam.AsDouble();
+                    endDistance = endParam.AsDouble();
+                }
+
+                if (forceX != null && Math.Abs(forceX.AsDouble()) > 0.001)
+                {
+                    loads.Add(new LoadAssignment
+                    {
+                        ElementID = host.UniqueId,
+                        LoadPattern = loadCaseName,
+                        LoadType = "LinearLoad",
+                        Value = forceX.AsDouble(),
+                        Unit = "N/m",
+                        Dir = 0,
+                        StartDistance = startDistance,
+                        EndDistance = endDistance,
+                        RelativeDistance = "Relative",
+                        SourcePlatform = "Revit",
+                        LastModified = DateTime.Now,
+                        SyncState = LoadSyncState.New
+                    });
+                }
+
+                if (forceY != null && Math.Abs(forceY.AsDouble()) > 0.001)
+                {
+                    loads.Add(new LoadAssignment
+                    {
+                        ElementID = host.UniqueId,
+                        LoadPattern = loadCaseName,
+                        LoadType = "LinearLoad",
+                        Value = forceY.AsDouble(),
+                        Unit = "N/m",
+                        Dir = 1,
+                        StartDistance = startDistance,
+                        EndDistance = endDistance,
+                        RelativeDistance = "Relative",
+                        SourcePlatform = "Revit",
+                        LastModified = DateTime.Now,
+                        SyncState = LoadSyncState.New
+                    });
+                }
+
+                if (forceZ != null && Math.Abs(forceZ.AsDouble()) > 0.001)
+                {
+                    loads.Add(new LoadAssignment
+                    {
+                        ElementID = host.UniqueId,
+                        LoadPattern = loadCaseName,
+                        LoadType = "LinearLoad",
+                        Value = forceZ.AsDouble(),
+                        Unit = "N/m",
+                        Dir = 2,
+                        StartDistance = startDistance,
+                        EndDistance = endDistance,
+                        RelativeDistance = "Relative",
+                        SourcePlatform = "Revit",
+                        LastModified = DateTime.Now,
+                        SyncState = LoadSyncState.New
+                    });
+                }
+
+                Parameter momentX = elem.LookupParameter("Moment X");
+                Parameter momentY = elem.LookupParameter("Moment Y");
+                Parameter momentZ = elem.LookupParameter("Moment Z");
+
+                if (momentX != null && Math.Abs(momentX.AsDouble()) > 0.001)
+                {
+                    loads.Add(new LoadAssignment
+                    {
+                        ElementID = host.UniqueId,
+                        LoadPattern = loadCaseName,
+                        LoadType = "LinearMomentLoad",
+                        Value = momentX.AsDouble(),
+                        Unit = "N-m/m",
+                        Dir = 0,
+                        StartDistance = startDistance,
+                        EndDistance = endDistance,
+                        RelativeDistance = "Relative",
+                        SourcePlatform = "Revit",
+                        LastModified = DateTime.Now,
+                        SyncState = LoadSyncState.New
+                    });
+                }
+
+                if (momentY != null && Math.Abs(momentY.AsDouble()) > 0.001)
+                {
+                    loads.Add(new LoadAssignment
+                    {
+                        ElementID = host.UniqueId,
+                        LoadPattern = loadCaseName,
+                        LoadType = "LinearMomentLoad",
+                        Value = momentY.AsDouble(),
+                        Unit = "N-m/m",
+                        Dir = 1,
+                        StartDistance = startDistance,
+                        EndDistance = endDistance,
+                        RelativeDistance = "Relative",
+                        SourcePlatform = "Revit",
+                        LastModified = DateTime.Now,
+                        SyncState = LoadSyncState.New
+                    });
+                }
+
+                if (momentZ != null && Math.Abs(momentZ.AsDouble()) > 0.001)
+                {
+                    loads.Add(new LoadAssignment
+                    {
+                        ElementID = host.UniqueId,
+                        LoadPattern = loadCaseName,
+                        LoadType = "LinearMomentLoad",
+                        Value = momentZ.AsDouble(),
+                        Unit = "N-m/m",
+                        Dir = 2,
+                        StartDistance = startDistance,
+                        EndDistance = endDistance,
+                        RelativeDistance = "Relative",
+                        SourcePlatform = "Revit",
+                        LastModified = DateTime.Now,
+                        SyncState = LoadSyncState.New
+                    });
+                }
+            }
+        }
+
+        private static void ExtractAreaLoads(Document doc, List<LoadAssignment> loads)
+        {
+            FilteredElementCollector collector = new FilteredElementCollector(doc)
+                .OfCategory(BuiltInCategory.OST_AreaLoads)
+                .WhereElementIsNotElementType();
+
+            foreach (Element elem in collector)
+            {
+                ElementId hostId = null;
+
+                Parameter hostParam = elem.LookupParameter("Host");
+                if (hostParam != null && hostParam.HasValue && hostParam.StorageType == StorageType.ElementId)
+                {
+                    hostId = hostParam.AsElementId();
+                }
+
+                if (hostId == null || hostId == ElementId.InvalidElementId)
+                {
+                    foreach (ElementId id in elem.GetDependentElements(null))
+                    {
+                        Element possibleHost = doc.GetElement(id);
+                        if (possibleHost != null &&
+                            (possibleHost.Category.Id.IntegerValue == (int)BuiltInCategory.OST_Floors ||
+                             possibleHost.Category.Id.IntegerValue == (int)BuiltInCategory.OST_StructuralFraming))
+                        {
+                            hostId = id;
+                            break;
+                        }
+                    }
+                }
+
+                if (hostId == null || hostId == ElementId.InvalidElementId) continue;
+
+                Element host = doc.GetElement(hostId);
+                if (host == null) continue;
+
+                Parameter forceX = elem.LookupParameter("Force X");
+                Parameter forceY = elem.LookupParameter("Force Y");
+                Parameter forceZ = elem.LookupParameter("Force Z");
+
+                Parameter loadCase = elem.LookupParameter("Load Case");
+                string loadCaseName = loadCase?.AsValueString() ?? "DEAD";
+
+                if (forceX != null && Math.Abs(forceX.AsDouble()) > 0.001)
+                {
+                    loads.Add(new LoadAssignment
+                    {
+                        ElementID = host.UniqueId,
+                        LoadPattern = loadCaseName,
+                        LoadType = "UniformLoad",
+                        Value = forceX.AsDouble(),
+                        Unit = "N/m²",
+                        Dir = 0,
+                        SourcePlatform = "Revit",
+                        LastModified = DateTime.Now,
+                        SyncState = LoadSyncState.New
+                    });
+                }
+
+                if (forceY != null && Math.Abs(forceY.AsDouble()) > 0.001)
+                {
+                    loads.Add(new LoadAssignment
+                    {
+                        ElementID = host.UniqueId,
+                        LoadPattern = loadCaseName,
+                        LoadType = "UniformLoad",
+                        Value = forceY.AsDouble(),
+                        Unit = "N/m²",
+                        Dir = 1,
+                        SourcePlatform = "Revit",
+                        LastModified = DateTime.Now,
+                        SyncState = LoadSyncState.New
+                    });
+                }
+
+                if (forceZ != null && Math.Abs(forceZ.AsDouble()) > 0.001)
+                {
+                    loads.Add(new LoadAssignment
+                    {
+                        ElementID = host.UniqueId,
+                        LoadPattern = loadCaseName,
+                        LoadType = "UniformLoad",
+                        Value = forceZ.AsDouble(),
+                        Unit = "N/m²",
+                        Dir = 2,
+                        SourcePlatform = "Revit",
+                        LastModified = DateTime.Now,
+                        SyncState = LoadSyncState.New
+                    });
+                }
+
+                Parameter momentX = elem.LookupParameter("Moment X");
+                Parameter momentY = elem.LookupParameter("Moment Y");
+                Parameter momentZ = elem.LookupParameter("Moment Z");
+
+                if (momentX != null && Math.Abs(momentX.AsDouble()) > 0.001)
+                {
+                    loads.Add(new LoadAssignment
+                    {
+                        ElementID = host.UniqueId,
+                        LoadPattern = loadCaseName,
+                        LoadType = "UniformMomentLoad",
+                        Value = momentX.AsDouble(),
+                        Unit = "N-m/m²",
+                        Dir = 0,
+                        SourcePlatform = "Revit",
+                        LastModified = DateTime.Now,
+                        SyncState = LoadSyncState.New
+                    });
+                }
+
+                if (momentY != null && Math.Abs(momentY.AsDouble()) > 0.001)
+                {
+                    loads.Add(new LoadAssignment
+                    {
+                        ElementID = host.UniqueId,
+                        LoadPattern = loadCaseName,
+                        LoadType = "UniformMomentLoad",
+                        Value = momentY.AsDouble(),
+                        Unit = "N-m/m²",
+                        Dir = 1,
+                        SourcePlatform = "Revit",
+                        LastModified = DateTime.Now,
+                        SyncState = LoadSyncState.New
+                    });
+                }
+
+                if (momentZ != null && Math.Abs(momentZ.AsDouble()) > 0.001)
+                {
+                    loads.Add(new LoadAssignment
+                    {
+                        ElementID = host.UniqueId,
+                        LoadPattern = loadCaseName,
+                        LoadType = "UniformMomentLoad",
+                        Value = momentZ.AsDouble(),
+                        Unit = "N-m/m²",
+                        Dir = 2,
+                        SourcePlatform = "Revit",
+                        LastModified = DateTime.Now,
+                        SyncState = LoadSyncState.New
+                    });
+                }
+            }
+        }
+    }
+}

--- a/LoadDatas/LoadAssignment.cs
+++ b/LoadDatas/LoadAssignment.cs
@@ -1,0 +1,54 @@
+﻿using System;
+
+namespace CSIXRevit.LoadData
+{
+    public class LoadAssignment
+    {
+        public string ElementID { get; set; }
+        public string LoadPattern { get; set; }
+        public string LoadType { get; set; }
+        public double Value { get; set; }
+        public string Unit { get; set; }
+        public int Dir { get; set; }
+        
+        public double? StartDistance { get; set; }
+        public double? EndDistance { get; set; }
+        public string RelativeDistance { get; set; }
+        
+        public string UniqueIdentifier { get; set; }
+        public string SourcePlatform { get; set; }
+        public DateTime LastModified { get; set; }
+        public LoadSyncState SyncState { get; set; }
+        
+        public void GenerateUniqueIdentifier()
+        {
+            if (string.IsNullOrEmpty(UniqueIdentifier))
+            {
+                UniqueIdentifier = $"{SourcePlatform}_{ElementID}_{LoadType}_{Guid.NewGuid().ToString("N").Substring(0, 8)}";
+            }
+        }
+        
+        public bool HasSameValues(LoadAssignment other)
+        {
+            if (other == null)
+                return false;
+                
+            return this.LoadPattern == other.LoadPattern &&
+                   this.LoadType == other.LoadType &&
+                   Math.Abs(this.Value - other.Value) < 0.0001 &&
+                   this.Unit == other.Unit &&
+                   this.Dir == other.Dir &&
+                   this.StartDistance == other.StartDistance &&
+                   this.EndDistance == other.EndDistance &&
+                   this.RelativeDistance == other.RelativeDistance;
+        }
+    }
+    
+    public enum LoadSyncState
+    {
+        New,
+        Modified,
+        Unchanged,
+        Deleted
+    }
+}

--- a/LoadDatas/LoadData.csproj
+++ b/LoadDatas/LoadData.csproj
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{1A6C234C-007E-43FB-AAF4-085977A4219A}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>LoadDatas</RootNamespace>
+    <AssemblyName>LoadDatas</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="ETABSv1">
+      <HintPath>..\..\..\..\..\..\..\Program Files\ETABS 22\ETABSv1.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="LoadAssignment.cs" />
+    <Compile Include="LoadSynchronizationManager.cs" />
+    <Compile Include="LoadSyncRegistry.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SyncReport.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/LoadDatas/LoadSyncRegistry.cs
+++ b/LoadDatas/LoadSyncRegistry.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using System.IO;
+
+namespace CSIXRevit.LoadData
+{
+    public class LoadSyncRegistry
+    {
+        private Dictionary<string, LoadAssignment> _loadRegistry;
+        private string _syncFilePath;
+
+        public LoadSyncRegistry(string syncFilePath)
+        {
+            _syncFilePath = syncFilePath;
+            LoadRegistry();
+        }
+
+        private void LoadRegistry()
+        {
+            if (File.Exists(_syncFilePath))
+            {
+                string json = File.ReadAllText(_syncFilePath);
+                _loadRegistry = JsonConvert.DeserializeObject<Dictionary<string, LoadAssignment>>(json)
+                    ?? new Dictionary<string, LoadAssignment>();
+            }
+            else
+            {
+                _loadRegistry = new Dictionary<string, LoadAssignment>();
+            }
+        }
+
+        public void SaveRegistry()
+        {
+            string json = JsonConvert.SerializeObject(_loadRegistry, Formatting.Indented);
+            Directory.CreateDirectory(Path.GetDirectoryName(_syncFilePath));
+            File.WriteAllText(_syncFilePath, json);
+        }
+
+        public void RegisterLoad(LoadAssignment load)
+        {
+            if (string.IsNullOrEmpty(load.UniqueIdentifier))
+            {
+                load.GenerateUniqueIdentifier();
+            }
+
+            _loadRegistry[load.UniqueIdentifier] = load;
+        }
+
+        public LoadAssignment GetLoad(string uniqueIdentifier)
+        {
+            return _loadRegistry.TryGetValue(uniqueIdentifier, out LoadAssignment load) ? load : null;
+        }
+
+        public List<LoadAssignment> GetAllLoads()
+        {
+            return new List<LoadAssignment>(_loadRegistry.Values);
+        }
+
+        public void RemoveLoad(string uniqueIdentifier)
+        {
+            _loadRegistry.Remove(uniqueIdentifier);
+        }
+
+        public bool ContainsLoad(string uniqueIdentifier)
+        {
+            return _loadRegistry.ContainsKey(uniqueIdentifier);
+        }
+    }
+}

--- a/LoadDatas/LoadSynchronizationManager.cs
+++ b/LoadDatas/LoadSynchronizationManager.cs
@@ -1,0 +1,218 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using ETABSv1;
+using CSIXRevit.LoadData;
+using loadData;
+
+namespace CSIXRevit.LoadData
+{
+    public class LoadSynchronizationManager
+    {
+        private LoadSyncRegistry _registry;
+
+        public LoadSynchronizationManager(string syncFilePath)
+        {
+            _registry = new LoadSyncRegistry(syncFilePath);
+        }
+
+        public SyncReport SyncFromRevitToEtabs(List<LoadAssignment> revitLoads, cSapModel etabsModel)
+        {
+            foreach (var load in _registry.GetAllLoads().Where(l => l.SourcePlatform == "Etabs"))
+            {
+                load.SyncState = LoadSyncState.Deleted;
+                _registry.RegisterLoad(load);
+            }
+
+            int newCount = 0;
+            int modifiedCount = 0;
+            int unchangedCount = 0;
+            int deletedCount = 0;
+
+            foreach (var revitLoad in revitLoads)
+            {
+                revitLoad.SourcePlatform = "Revit";
+                revitLoad.LastModified = DateTime.Now;
+
+                var existingLoads = _registry.GetAllLoads()
+                    .Where(l => l.ElementID == revitLoad.ElementID &&
+                               l.LoadType == revitLoad.LoadType &&
+                               l.LoadPattern == revitLoad.LoadPattern &&
+                               l.Dir == revitLoad.Dir)
+                    .ToList();
+
+                if (existingLoads.Any())
+                {
+                    var existingLoad = existingLoads.First();
+
+                    if (!existingLoad.HasSameValues(revitLoad))
+                    {
+                        existingLoad.Value = revitLoad.Value;
+                        existingLoad.StartDistance = revitLoad.StartDistance;
+                        existingLoad.EndDistance = revitLoad.EndDistance;
+                        existingLoad.LastModified = DateTime.Now;
+                        existingLoad.SyncState = LoadSyncState.Modified;
+
+                        UpdateEtabsLoad(etabsModel, existingLoad);
+                        modifiedCount++;
+                    }
+                    else
+                    {
+                        existingLoad.SyncState = LoadSyncState.Unchanged;
+                        unchangedCount++;
+                    }
+
+                    _registry.RegisterLoad(existingLoad);
+                }
+                else
+                {
+                    revitLoad.SyncState = LoadSyncState.New;
+                    _registry.RegisterLoad(revitLoad);
+
+                    CreateEtabsLoad(etabsModel, revitLoad);
+                    newCount++;
+                }
+            }
+
+            foreach (var loadToDelete in _registry.GetAllLoads().Where(l => l.SyncState == LoadSyncState.Deleted).ToList())
+            {
+                DeleteEtabsLoad(etabsModel, loadToDelete);
+                _registry.RemoveLoad(loadToDelete.UniqueIdentifier);
+                deletedCount++;
+            }
+
+            _registry.SaveRegistry();
+
+            return new SyncReport
+            {
+                NewLoads = newCount,
+                ModifiedLoads = modifiedCount,
+                DeletedLoads = deletedCount,
+                UnchangedLoads = unchangedCount,
+                TotalLoads = _registry.GetAllLoads().Count
+            };
+        }
+
+        private void UpdateEtabsLoad(cSapModel model, LoadAssignment load)
+        {
+            switch (load.LoadType)
+            {
+                case "PointLoad":
+                    UpdateEtabsPointLoad(model, load);
+                    break;
+                case "UniformLoad":
+                    UpdateEtabsUniformLoad(model, load);
+                    break;
+                case "LinearLoad":
+                    UpdateEtabsLinearLoad(model, load);
+                    break;
+            }
+        }
+
+        private void CreateEtabsLoad(cSapModel model, LoadAssignment load)
+        {
+            switch (load.LoadType)
+            {
+                case "PointLoad":
+                    CreateEtabsPointLoad(model, load);
+                    break;
+                case "UniformLoad":
+                    CreateEtabsUniformLoad(model, load);
+                    break;
+                case "LinearLoad":
+                    CreateEtabsLinearLoad(model, load);
+                    break;
+            }
+        }
+
+        private void DeleteEtabsLoad(cSapModel model, LoadAssignment load)
+        {
+            switch (load.LoadType)
+            {
+                case "PointLoad":
+                    DeleteEtabsPointLoad(model, load);
+                    break;
+                case "UniformLoad":
+                    DeleteEtabsUniformLoad(model, load);
+                    break;
+                case "LinearLoad":
+                    DeleteEtabsLinearLoad(model, load);
+                    break;
+            }
+        }
+
+        private void UpdateEtabsPointLoad(cSapModel model, LoadAssignment load)
+        {
+            DeleteEtabsPointLoad(model, load);
+            CreateEtabsPointLoad(model, load);
+        }
+
+        private void CreateEtabsPointLoad(cSapModel model, LoadAssignment load)
+        {
+            // Create a Value array for the point load as per ETABS API documentation
+            double[] value = new double[6] { 0, 0, 0, 0, 0, 0 };
+
+            // Set the appropriate force component based on direction
+            value[load.Dir] = load.Value;
+
+            // Use the correct signature from ETABS API documentation
+            model.PointObj.SetLoadForce(load.ElementID, load.LoadPattern, ref value, false, "Global", 0);
+        }
+
+        private void DeleteEtabsPointLoad(cSapModel model, LoadAssignment load)
+        {
+            model.PointObj.DeleteLoadForce(load.ElementID, load.LoadPattern);
+        }
+
+        private void UpdateEtabsUniformLoad(cSapModel model, LoadAssignment load)
+        {
+            DeleteEtabsUniformLoad(model, load);
+            CreateEtabsUniformLoad(model, load);
+        }
+
+        private void CreateEtabsUniformLoad(cSapModel model, LoadAssignment load)
+        {
+            // Create scalar values for the uniform load as per ETABS API documentation
+            double value = load.Value;
+            int dir = load.Dir + 1; // Convert 0-based index to 1-based direction
+
+            // Use the correct signature from ETABS API documentation
+            model.AreaObj.SetLoadUniform(load.ElementID, load.LoadPattern, value, dir, true, "Global", 0);
+        }
+
+        private void DeleteEtabsUniformLoad(cSapModel model, LoadAssignment load)
+        {
+            model.AreaObj.DeleteLoadUniform(load.ElementID, load.LoadPattern);
+        }
+
+        private void UpdateEtabsLinearLoad(cSapModel model, LoadAssignment load)
+        {
+            DeleteEtabsLinearLoad(model, load);
+            CreateEtabsLinearLoad(model, load);
+        }
+
+        private void CreateEtabsLinearLoad(cSapModel model, LoadAssignment load)
+        {
+            // Get start and end distances
+            double startDist = load.StartDistance ?? 0;
+            double endDist = load.EndDistance ?? 1;
+
+            // Create scalar values for the linear load as per ETABS API documentation
+            int myType = 1; // Force per unit length
+            int dir = load.Dir + 1; // Convert 0-based index to 1-based direction
+            double val1 = load.Value; // Start value
+            double val2 = load.Value; // End value (same for constant load)
+            bool relDist = load.RelativeDistance == "Relative";
+
+            // Use the correct signature from ETABS API documentation
+            model.FrameObj.SetLoadDistributed(load.ElementID, load.LoadPattern, myType, dir,
+                                             startDist, endDist, val1, val2,
+                                             "Global", relDist, true, 0);
+        }
+
+        private void DeleteEtabsLinearLoad(cSapModel model, LoadAssignment load)
+        {
+            model.FrameObj.DeleteLoadDistributed(load.ElementID, load.LoadPattern);
+        }
+    }
+}

--- a/LoadDatas/Properties/AssemblyInfo.cs
+++ b/LoadDatas/Properties/AssemblyInfo.cs
@@ -1,0 +1,33 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("LoadDatas")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("LoadDatas")]
+[assembly: AssemblyCopyright("Copyright ©  2025")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("1a6c234c-007e-43fb-aaf4-085977a4219a")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/LoadDatas/SyncReport.cs
+++ b/LoadDatas/SyncReport.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace loadData
+
+{
+    public class SyncReport
+    {
+        public int NewLoads { get; set; }
+        public int ModifiedLoads { get; set; }
+        public int DeletedLoads { get; set; }
+        public int UnchangedLoads { get; set; }
+        public int TotalLoads { get; set; }
+
+        public override string ToString()
+        {
+            return $"Synchronization Report:\n" +
+                   $"- New loads: {NewLoads}\n" +
+                   $"- Modified loads: {ModifiedLoads}\n" +
+                   $"- Deleted loads: {DeletedLoads}\n" +
+                   $"- Unchanged loads: {UnchangedLoads}\n" +
+                   $"- Total loads: {TotalLoads}";
+        }
+    }
+}

--- a/LoadDatas/packages.config
+++ b/LoadDatas/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net48" />
+</packages>

--- a/ReinforcementFromEtab/ReinforcementFromEtab.csproj
+++ b/ReinforcementFromEtab/ReinforcementFromEtab.csproj
@@ -17,8 +17,7 @@
 
   <ItemGroup>
     <Reference Include="ETABSv1">
-      <HintPath>..\..\..\..\..\..\Program Files\Computers and Structures\ETABS 22\ETABSv1.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\..\..\..\..\..\..\Program Files\ETABS 22\ETABSv1.dll</HintPath>
     </Reference>
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>

--- a/StructLink_X/StructLink_X.csproj
+++ b/StructLink_X/StructLink_X.csproj
@@ -24,12 +24,10 @@
 
   <ItemGroup>
     <Reference Include="RevitAPI">
-      <HintPath>..\..\..\..\..\..\Program Files\Autodesk\Revit 2022\RevitAPI.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\..\..\..\..\..\..\Program Files\Autodesk\Revit 2022\RevitAPI.dll</HintPath>
     </Reference>
     <Reference Include="RevitAPIUI">
-      <HintPath>..\..\..\..\..\..\Program Files\Autodesk\Revit 2022\RevitAPIUI.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\..\..\..\..\..\..\Program Files\Autodesk\Revit 2022\RevitAPIUI.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/ToEtabs/Importers/ImportLoads.cs
+++ b/ToEtabs/Importers/ImportLoads.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using ETABSv1;
+using CSIXRevit.LoadData;
+using Newtonsoft.Json;
+using loadData;
+
+namespace CSIXRevit.ToEtabs
+{
+    public class ImportLoads
+    {
+        public static SyncReport ImportLoadData(List<LoadAssignment> loads, cSapModel _sapModel)
+        {
+            CreateLoadPatterns(_sapModel, loads);
+
+            var syncManager = new LoadSynchronizationManager(
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                "RevitEtabsExchange", "LoadSyncRegistry.json"));
+
+            return syncManager.SyncFromRevitToEtabs(loads, _sapModel);
+        }
+
+        private static void CreateLoadPatterns(cSapModel model, List<LoadAssignment> loads)
+        {
+            HashSet<string> loadPatterns = new HashSet<string>();
+            foreach (var load in loads)
+            {
+                loadPatterns.Add(load.LoadPattern);
+            }
+
+            foreach (string pattern in loadPatterns)
+            {
+                int patternCount = 0;
+                string[] patternNames = null;
+                int ret = model.LoadPatterns.GetNameList(ref patternCount, ref patternNames);
+
+                bool patternExists = false;
+                if (patternNames != null)
+                {
+                    foreach (string existingPattern in patternNames)
+                    {
+                        if (existingPattern == pattern)
+                        {
+                            patternExists = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (!patternExists)
+                {
+                    // Cast the integer to the eLoadPatternType enum
+                    model.LoadPatterns.Add(pattern, (ETABSv1.eLoadPatternType)1);
+                }
+            }
+        }
+    }
+}

--- a/ToEtabs/ToEtabs.csproj
+++ b/ToEtabs/ToEtabs.csproj
@@ -16,12 +16,13 @@
 
 	<ItemGroup>
 	  <ProjectReference Include="..\ElementsData\ElementsData.csproj" />
+	  <ProjectReference Include="..\LoadDatas\LoadData.csproj" />
 	  <ProjectReference Include="..\Styles\Styles.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>
 	  <Reference Include="ETABSv1">
-	    <HintPath>..\..\..\..\..\..\..\Program Files\Computers and Structures\ETABS 22\ETABSv1.dll</HintPath>
+	    <HintPath>..\..\..\..\..\..\..\Program Files\ETABS 22\ETABSv1.dll</HintPath>
 	    <Private>False</Private>
 	  </Reference>
 	</ItemGroup>

--- a/ToEtabs/UnifiedView.xaml
+++ b/ToEtabs/UnifiedView.xaml
@@ -1,0 +1,182 @@
+﻿<Window x:Class="ToEtabs.Views.UnifiedView"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Revit ↔ ETABS Integration" Height="600" Width="500"
+        WindowStartupLocation="CenterScreen">
+
+    <DockPanel>
+        <!-- Header -->
+        <Border Background="#186bff" Height="50" DockPanel.Dock="Top">
+            <TextBlock Text="Revit ↔ ETABS Integration" HorizontalAlignment="Center"
+                       VerticalAlignment="Center" Foreground="White" FontSize="16" FontWeight="SemiBold"/>
+        </Border>
+
+        <!-- Main Content -->
+        <Grid Margin="15">
+            <TabControl>
+                <!-- Elements Import Tab -->
+                <TabItem Header="Elements">
+                    <ScrollViewer VerticalScrollBarVisibility="Auto">
+                        <StackPanel Margin="10">
+                            <!-- File Selection for Elements -->
+                            <GroupBox Header="JSON File Selection" Margin="0,0,0,15">
+                                <Grid Margin="5">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBox Text="{Binding ImportFilePath}" 
+                                            IsReadOnly="True" Height="30"
+                                            VerticalContentAlignment="Center"/>
+                                    <Button Grid.Column="1" Content="Browse" 
+                                           Click="BrowseElementsButton_Click"
+                                           Height="30" Width="80" Margin="5,0,0,0"
+                                           Background="#186bff" Foreground="White"/>
+                                </Grid>
+                            </GroupBox>
+
+                            <!-- Material Selection -->
+                            <GroupBox Header="Material Selection" Margin="0,0,0,15">
+                                <ComboBox ItemsSource="{Binding DefinedConcreteMaterial}" 
+                                         SelectedItem="{Binding SelectedConcreteMaterial, Mode=TwoWay}"
+                                         Height="35" Margin="5"/>
+                            </GroupBox>
+
+                            <!-- Element Types -->
+                            <GroupBox Header="Structural Elements" Margin="0,0,0,15">
+                                <StackPanel Margin="10">
+                                    <CheckBox Content="Columns" IsChecked="{Binding IsColumnsChecked}" Margin="0,5"/>
+                                    <CheckBox Content="Walls" IsChecked="{Binding IsWallsChecked}" Margin="0,5"/>
+                                    <CheckBox Content="Beams" IsChecked="{Binding IsBeamsChecked}" Margin="0,5"/>
+                                    <CheckBox Content="Slabs" IsChecked="{Binding IsSlabsChecked}" Margin="0,5"/>
+                                </StackPanel>
+                            </GroupBox>
+
+                            <!-- Status -->
+                            <TextBlock Text="{Binding ElementsStatusMessage}" 
+                                      TextWrapping="Wrap" Margin="0,10"
+                                      HorizontalAlignment="Center" FontWeight="SemiBold"/>
+
+                            <!-- Import Button -->
+                            <Button Content="Import Elements from JSON" 
+                                   Click="ImportElementsButton_Click"
+                                   Height="35" Margin="5" Background="#186bff" Foreground="White"/>
+                        </StackPanel>
+                    </ScrollViewer>
+                </TabItem>
+
+                <!-- Load Import Tab -->
+                <TabItem Header="Import Loads">
+                    <ScrollViewer VerticalScrollBarVisibility="Auto">
+                        <StackPanel Margin="10">
+                            <!-- File Selection -->
+                            <GroupBox Header="Load File Selection" Margin="0,0,0,15">
+                                <Grid Margin="5">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBox Text="{Binding ImportFilePath}" 
+                                            IsReadOnly="True" Height="30"
+                                            VerticalContentAlignment="Center"/>
+                                    <Button Grid.Column="1" Content="Browse" 
+                                           Click="BrowseImportButton_Click"
+                                           Height="30" Width="80" Margin="5,0,0,0"
+                                           Background="#186bff" Foreground="White"/>
+                                </Grid>
+                            </GroupBox>
+
+                            <!-- Load Types -->
+                            <GroupBox Header="Load Types to Import" Margin="0,0,0,15">
+                                <StackPanel Margin="10">
+                                    <CheckBox Content="Point Loads" IsChecked="{Binding IsImportPointLoadsChecked}" Margin="0,5"/>
+                                    <CheckBox Content="Linear Loads" IsChecked="{Binding IsImportLinearLoadsChecked}" Margin="0,5"/>
+                                    <CheckBox Content="Uniform Loads" IsChecked="{Binding IsImportUniformLoadsChecked}" Margin="0,5"/>
+                                </StackPanel>
+                            </GroupBox>
+
+                            <!-- Import Options -->
+                            <GroupBox Header="Import Options" Margin="0,0,0,15">
+                                <StackPanel Margin="10">
+                                    <CheckBox Content="Replace existing loads" IsChecked="{Binding ReplaceExistingLoads}" Margin="0,5"/>
+                                    <CheckBox Content="Create missing load patterns" IsChecked="{Binding CreateMissingLoadPatterns}" Margin="0,5"/>
+                                    <CheckBox Content="Show summary after import" IsChecked="{Binding ShowSummaryAfterImport}" Margin="0,5"/>
+                                </StackPanel>
+                            </GroupBox>
+
+                            <!-- Load Preview - Always Visible -->
+                            <Border Name="LoadPreviewBorder" BorderBrush="#DDDDDD" BorderThickness="1" 
+                                   Margin="0,0,0,15" MaxHeight="120">
+                                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                                    <TextBlock Text="{Binding ImportLoadSummary}" 
+                                              TextWrapping="Wrap" Margin="10"
+                                              FontSize="12"/>
+                                </ScrollViewer>
+                            </Border>
+
+                            <!-- Status -->
+                            <TextBlock Text="{Binding ImportStatusMessage}" 
+                                      TextWrapping="Wrap" Margin="0,10"
+                                      HorizontalAlignment="Center" FontWeight="SemiBold"/>
+
+                            <!-- Import Button -->
+                            <Button Content="Import Loads to ETABS" 
+                                   Click="ImportLoadsButton_Click"
+                                   Height="35" Margin="5" Background="#186bff" Foreground="White"/>
+                        </StackPanel>
+                    </ScrollViewer>
+                </TabItem>
+
+                <!-- Load Export Tab -->
+                <TabItem Header="Export Loads">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="*"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+
+                        <ScrollViewer Grid.Row="0" VerticalScrollBarVisibility="Auto">
+                            <StackPanel Margin="10">
+                                <!-- File Selection -->
+                                <GroupBox Header="Export Location" Margin="0,0,0,15">
+                                    <Grid Margin="5">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <TextBox Text="{Binding ExportFilePath}" 
+                                                Height="30" VerticalContentAlignment="Center"/>
+                                        <Button Grid.Column="1" Content="Browse" 
+                                               Command="{Binding BrowseExportFileCommand}"
+                                               Height="30" Width="80" Margin="5,0,0,0"
+                                               Background="#186bff" Foreground="White"/>
+                                    </Grid>
+                                </GroupBox>
+
+                                <!-- Load Types -->
+                                <GroupBox Header="Load Types to Export" Margin="0,0,0,15">
+                                    <StackPanel Margin="10">
+                                        <CheckBox Content="Point Loads" IsChecked="{Binding IsExportPointLoadsChecked}" Margin="0,5"/>
+                                        <CheckBox Content="Linear Loads" IsChecked="{Binding IsExportLinearLoadsChecked}" Margin="0,5"/>
+                                        <CheckBox Content="Uniform Loads" IsChecked="{Binding IsExportUniformLoadsChecked}" Margin="0,5"/>
+                                    </StackPanel>
+                                </GroupBox>
+
+                                <!-- Status -->
+                                <TextBlock Text="{Binding ExportStatusMessage}" 
+                                          TextWrapping="Wrap" Margin="0,10"
+                                          HorizontalAlignment="Center" FontWeight="SemiBold"/>
+                            </StackPanel>
+                        </ScrollViewer>
+
+                        <!-- Export Button - Always Visible at Bottom -->
+                        <Button Grid.Row="1" Content="Export Loads to JSON" 
+                               Click="ExportButton_Click"
+                               Height="40" Margin="10" Background="#186bff" Foreground="White"
+                               FontWeight="SemiBold" FontSize="14"/>
+                    </Grid>
+                </TabItem>
+            </TabControl>
+        </Grid>
+    </DockPanel>
+</Window>

--- a/ToEtabs/UnifiedView.xaml.cs
+++ b/ToEtabs/UnifiedView.xaml.cs
@@ -1,0 +1,71 @@
+﻿using System.Windows;
+using ETABSv1;
+using ToEtabs.ViewModels;
+using System.ComponentModel;
+
+namespace ToEtabs.Views
+{
+    public partial class UnifiedView : Window
+    {
+        private UnifiedViewModel _viewModel;
+
+        public UnifiedView(cSapModel etabsModel)
+        {
+            InitializeComponent();
+            _viewModel = new UnifiedViewModel(etabsModel);
+            DataContext = _viewModel;
+
+            // Subscribe to property changes to handle visibility manually
+            _viewModel.PropertyChanged += ViewModel_PropertyChanged;
+        }
+
+        private void ViewModel_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(_viewModel.ImportLoadSummary))
+            {
+                // Handle load preview visibility
+                if (string.IsNullOrEmpty(_viewModel.ImportLoadSummary))
+                {
+                    LoadPreviewBorder.Visibility = Visibility.Collapsed;
+                }
+                else
+                {
+                    LoadPreviewBorder.Visibility = Visibility.Visible;
+                }
+            }
+        }
+
+        // Browse button handlers
+        private void BrowseImportButton_Click(object sender, RoutedEventArgs e)
+        {
+            _viewModel.BrowseImportFile();
+        }
+
+        private void BrowseExportButton_Click(object sender, RoutedEventArgs e)
+        {
+            _viewModel.BrowseExportFile();
+        }
+
+        private void BrowseElementsButton_Click(object sender, RoutedEventArgs e)
+        {
+            _viewModel.BrowseImportFile(); // Same method, different button for clarity
+        }
+
+        // Main action button handlers
+        private void ImportLoadsButton_Click(object sender, RoutedEventArgs e)
+        {
+            // Use the simple direct import method instead of the sync system
+            _viewModel.PerformSimpleLoadImport();
+        }
+
+        private void ExportButton_Click(object sender, RoutedEventArgs e)
+        {
+            _viewModel.PerformLoadExport();
+        }
+
+        private void ImportElementsButton_Click(object sender, RoutedEventArgs e)
+        {
+            _viewModel.PerformElementImport();
+        }
+    }
+}

--- a/ToEtabs/cPlugin.cs
+++ b/ToEtabs/cPlugin.cs
@@ -1,7 +1,9 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
+using System.Windows;
 using ETABSv1;
 using System.Reflection;
-using ToEtabs.ViewModels;
+using ToEtabs.Views;
 
 namespace ToEtabs
 {
@@ -9,20 +11,35 @@ namespace ToEtabs
     {
         public void Main(ref cSapModel SapModel, ref cPluginCallback ISapPlugin)
         {
-            AppDomain.CurrentDomain.AssemblyResolve += ResolveStyleLibrary;
+            try
+            {
+                // Register assembly resolver for loading WPF libraries
+                AppDomain.CurrentDomain.AssemblyResolve += ResolveStyleLibrary;
 
-            MainWindowViewModel ViewModel = new MainWindowViewModel(SapModel);
-            MainWindow mainWindow = new MainWindow(ViewModel);
-            mainWindow.ShowDialog();
+                // Store the SapModel in a local variable to avoid using ref in lambdas
+                cSapModel etabsModel = SapModel;
 
-            ISapPlugin.Finish(0);
+                // Create and show the unified view directly
+                var unifiedView = new UnifiedView(etabsModel);
+                unifiedView.ShowDialog();
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Error in plugin: {ex.Message}\n\n{ex.StackTrace}", "Plugin Error",
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+            finally
+            {
+                ISapPlugin.Finish(0);
+            }
         }
 
         public int Info(ref string Text)
         {
-           Text = "ToEtabs Plugin From ELGaiar";
+            Text = "Revit-ETABS Integration Plugin - Unified Interface";
             return 0;
         }
+
         private static Assembly ResolveStyleLibrary(object sender, ResolveEventArgs args)
         {
             var requestedAssembly = new AssemblyName(args.Name).Name + ".dll";

--- a/ToEtabs/viewmodels/UnifiedViewModel.cs
+++ b/ToEtabs/viewmodels/UnifiedViewModel.cs
@@ -1,0 +1,896 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Windows;
+using System.Windows.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.Win32;
+using Newtonsoft.Json;
+using CSIXRevit.LoadData;
+using ETABSv1;
+using ElementsData;
+using ToEtabs.Importers;
+using ToEtabs;
+using ToEtabs.Utilities;
+using ElementsData.Geometry;
+
+namespace ToEtabs.ViewModels
+{
+    public partial class UnifiedViewModel : ObservableObject
+    {
+        private readonly cSapModel _etabsModel;
+
+        #region Import Properties
+        [ObservableProperty]
+        private string importFilePath;
+
+        [ObservableProperty]
+        private bool isImportPointLoadsChecked = true;
+
+        [ObservableProperty]
+        private bool isImportLinearLoadsChecked = true;
+
+        [ObservableProperty]
+        private bool isImportUniformLoadsChecked = true;
+
+        [ObservableProperty]
+        private bool replaceExistingLoads = true;
+
+        [ObservableProperty]
+        private bool createMissingLoadPatterns = true;
+
+        [ObservableProperty]
+        private bool showSummaryAfterImport = true;
+
+        [ObservableProperty]
+        private string importStatusMessage = "Select a JSON file to import loads.";
+
+        [ObservableProperty]
+        private string importLoadSummary;
+        #endregion
+
+        #region Export Properties
+        [ObservableProperty]
+        private string exportFilePath;
+
+        [ObservableProperty]
+        private bool isExportPointLoadsChecked = true;
+
+        [ObservableProperty]
+        private bool isExportLinearLoadsChecked = true;
+
+        [ObservableProperty]
+        private bool isExportUniformLoadsChecked = true;
+
+        [ObservableProperty]
+        private string exportStatusMessage = "Select export location for JSON file.";
+
+        [ObservableProperty]
+        private bool isExporting;
+        #endregion
+
+        #region Elements Properties
+        [ObservableProperty]
+        private ObservableCollection<string> definedConcreteMaterial;
+
+        [ObservableProperty]
+        private string selectedConcreteMaterial;
+
+        [ObservableProperty]
+        private bool isColumnsChecked = true;
+
+        [ObservableProperty]
+        private bool isWallsChecked = true;
+
+        [ObservableProperty]
+        private bool isBeamsChecked = true;
+
+        [ObservableProperty]
+        private bool isSlabsChecked = true;
+
+        [ObservableProperty]
+        private string elementsStatusMessage = "Select elements to import.";
+        #endregion
+
+        #region Global Properties
+        [ObservableProperty]
+        private bool isProcessing;
+
+        [ObservableProperty]
+        private string processingMessage;
+        #endregion
+
+        #region Commands
+        public ICommand BrowseImportFileCommand { get; private set; }
+        public ICommand ImportLoadsCommand { get; private set; }
+        public ICommand BrowseExportFileCommand { get; private set; }
+        public ICommand ExportLoadsCommand { get; private set; }
+        public ICommand ImportElementsCommand { get; private set; }
+        #endregion
+
+        public UnifiedViewModel(cSapModel etabsModel)
+        {
+            _etabsModel = etabsModel;
+            InitializeMaterials();
+            InitializeCommands();
+        }
+
+        private void InitializeCommands()
+        {
+            BrowseImportFileCommand = new RelayCommand(BrowseImportFile);
+            ImportLoadsCommand = new RelayCommand(PerformLoadImport, CanImportLoads);
+            BrowseExportFileCommand = new RelayCommand(BrowseExportFile);
+            ExportLoadsCommand = new RelayCommand(PerformLoadExport, CanExportLoads);
+            ImportElementsCommand = new RelayCommand(PerformElementImport, CanImportElements);
+        }
+
+        private bool CanImportLoads()
+        {
+            return !string.IsNullOrEmpty(ImportFilePath) &&
+                   (IsImportPointLoadsChecked || IsImportLinearLoadsChecked || IsImportUniformLoadsChecked) &&
+                   !IsProcessing;
+        }
+
+        private bool CanExportLoads()
+        {
+            bool hasPath = !string.IsNullOrEmpty(ExportFilePath);
+            bool hasLoadTypes = (IsExportPointLoadsChecked || IsExportLinearLoadsChecked || IsExportUniformLoadsChecked);
+            bool notProcessing = !IsProcessing;
+
+            // Debug output
+            System.Diagnostics.Debug.WriteLine($"CanExportLoads: Path={hasPath}, LoadTypes={hasLoadTypes}, NotProcessing={notProcessing}");
+
+            return hasPath && hasLoadTypes && notProcessing;
+        }
+
+        private bool CanImportElements()
+        {
+            return !string.IsNullOrEmpty(SelectedConcreteMaterial) &&
+                   !string.IsNullOrEmpty(ImportFilePath) &&
+                   (IsColumnsChecked || IsWallsChecked || IsBeamsChecked || IsSlabsChecked) &&
+                   !IsProcessing;
+        }
+
+        private void InitializeMaterials()
+        {
+            try
+            {
+                var materials = MatrialProperties.GetMaterialNames(_etabsModel);
+                DefinedConcreteMaterial = new ObservableCollection<string>(materials);
+
+                if (DefinedConcreteMaterial.Count > 0)
+                {
+                    SelectedConcreteMaterial = DefinedConcreteMaterial[0];
+                }
+                else
+                {
+                    DefinedConcreteMaterial.Add("C30/37");
+                    SelectedConcreteMaterial = "C30/37";
+                }
+            }
+            catch (Exception ex)
+            {
+                DefinedConcreteMaterial = new ObservableCollection<string>
+                {
+                    "C25/30",
+                    "C30/37",
+                    "C35/45",
+                    "C40/50"
+                };
+                SelectedConcreteMaterial = "C30/37";
+                ElementsStatusMessage = $"Using default materials. Error: {ex.Message}";
+            }
+        }
+
+        #region Import Methods
+        public void BrowseImportFile()
+        {
+            var openFileDialog = new OpenFileDialog
+            {
+                Filter = "JSON files (*.json)|*.json",
+                Title = "Open Load Data File",
+                DefaultExt = "json"
+            };
+
+            if (openFileDialog.ShowDialog() == true)
+            {
+                ImportFilePath = openFileDialog.FileName;
+                LoadImportFileContents();
+                CommandManager.InvalidateRequerySuggested();
+            }
+        }
+
+        private void LoadImportFileContents()
+        {
+            if (string.IsNullOrEmpty(ImportFilePath) || !File.Exists(ImportFilePath))
+            {
+                ImportLoadSummary = "";
+                return;
+            }
+
+            try
+            {
+                string jsonContent = File.ReadAllText(ImportFilePath);
+                var importData = JsonConvert.DeserializeObject<Dictionary<string, object>>(jsonContent);
+
+                if (importData != null)
+                {
+                    var summary = "";
+                    int totalLoads = 0;
+
+                    // Check for loads
+                    if (importData.ContainsKey("loads"))
+                    {
+                        var loadsJson = importData["loads"].ToString();
+                        var loadData = JsonConvert.DeserializeObject<List<LoadAssignment>>(loadsJson) ?? new List<LoadAssignment>();
+
+                        int pointLoads = 0, linearLoads = 0, uniformLoads = 0;
+                        HashSet<string> loadPatterns = new HashSet<string>();
+
+                        foreach (var load in loadData)
+                        {
+                            if (load.LoadType.Contains("Point")) pointLoads++;
+                            else if (load.LoadType.Contains("Linear") || load.LoadType.Contains("Distributed")) linearLoads++;
+                            else if (load.LoadType.Contains("Uniform")) uniformLoads++;
+
+                            if (!string.IsNullOrEmpty(load.LoadPattern))
+                                loadPatterns.Add(load.LoadPattern);
+                        }
+
+                        totalLoads = loadData.Count;
+                        summary += $"Loads ({totalLoads}):\n• {pointLoads} point loads\n• {linearLoads} linear loads\n• {uniformLoads} uniform loads\n";
+                        if (loadPatterns.Count > 0)
+                            summary += $"Load patterns: {string.Join(", ", loadPatterns)}\n\n";
+                    }
+
+                    // Check for structural elements
+                    var elementCounts = new Dictionary<string, int>();
+                    string[] elementTypes = { "beams", "columns", "slabs", "walls" };
+
+                    foreach (string elementType in elementTypes)
+                    {
+                        if (importData.ContainsKey(elementType))
+                        {
+                            var elementJson = importData[elementType].ToString();
+                            if (elementJson.StartsWith("["))
+                            {
+                                var elements = JsonConvert.DeserializeObject<List<object>>(elementJson) ?? new List<object>();
+                                elementCounts[elementType] = elements.Count;
+                            }
+                        }
+                    }
+
+                    if (elementCounts.Count > 0)
+                    {
+                        summary += "Structural Elements:\n";
+                        foreach (var kvp in elementCounts)
+                        {
+                            summary += $"• {kvp.Value} {kvp.Key}\n";
+                        }
+                    }
+
+                    ImportLoadSummary = summary.Trim();
+                    ImportStatusMessage = totalLoads > 0 ? "Ready to import loads." : "Ready to import elements.";
+                }
+                else
+                {
+                    ImportLoadSummary = "No data found in file.";
+                    ImportStatusMessage = "No data found in the selected file.";
+                }
+            }
+            catch (Exception ex)
+            {
+                ImportLoadSummary = $"Error loading file: {ex.Message}";
+                ImportStatusMessage = $"Error: {ex.Message}";
+            }
+        }
+
+        public void PerformLoadImport()
+        {
+            if (string.IsNullOrEmpty(ImportFilePath))
+            {
+                MessageBox.Show("Please select a JSON file first.", "No File Selected",
+                    MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            if (!IsImportPointLoadsChecked && !IsImportLinearLoadsChecked && !IsImportUniformLoadsChecked)
+            {
+                MessageBox.Show("Please select at least one load type to import.", "No Load Types Selected",
+                    MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            try
+            {
+                IsProcessing = true;
+                ProcessingMessage = "Importing loads...";
+                ImportStatusMessage = "Importing loads...";
+
+                string jsonContent = File.ReadAllText(ImportFilePath);
+                var importData = JsonConvert.DeserializeObject<Dictionary<string, object>>(jsonContent);
+
+                if (importData != null && importData.ContainsKey("loads"))
+                {
+                    var loadsJson = importData["loads"].ToString();
+                    var allLoads = JsonConvert.DeserializeObject<List<LoadAssignment>>(loadsJson) ?? new List<LoadAssignment>();
+                    var filteredLoads = new List<LoadAssignment>();
+
+                    // Filter loads based on selection
+                    foreach (var load in allLoads)
+                    {
+                        if ((load.LoadType.Contains("Point") && IsImportPointLoadsChecked) ||
+                            ((load.LoadType.Contains("Linear") || load.LoadType.Contains("Distributed")) && IsImportLinearLoadsChecked) ||
+                            (load.LoadType.Contains("Uniform") && IsImportUniformLoadsChecked))
+                        {
+                            filteredLoads.Add(load);
+                        }
+                    }
+
+                    // Debug: Show what we're trying to import
+                    MessageBox.Show($"Found {allLoads.Count} total loads in file.\n" +
+                                   $"Filtered to {filteredLoads.Count} loads based on your selection.\n" +
+                                   $"About to import...", "Debug Info");
+
+                    // Use the load synchronization system
+                    var syncReport = CSIXRevit.ToEtabs.ImportLoads.ImportLoadData(filteredLoads, _etabsModel);
+
+                    ImportStatusMessage = $"Import completed: {syncReport.NewLoads + syncReport.ModifiedLoads} loads imported.";
+
+                    if (ShowSummaryAfterImport)
+                    {
+                        MessageBox.Show(syncReport.ToString(), "Import Summary",
+                            MessageBoxButton.OK, MessageBoxImage.Information);
+                    }
+                }
+                else
+                {
+                    ImportStatusMessage = "No load data found in the file.";
+                    MessageBox.Show("No 'loads' key found in the JSON file. Please check the file format.",
+                                   "No Load Data", MessageBoxButton.OK, MessageBoxImage.Warning);
+                }
+            }
+            catch (Exception ex)
+            {
+                ImportStatusMessage = $"Error during import: {ex.Message}";
+                MessageBox.Show($"Error during import: {ex.Message}\n\nStack trace: {ex.StackTrace}",
+                               "Import Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+            finally
+            {
+                IsProcessing = false;
+                CommandManager.InvalidateRequerySuggested();
+            }
+        }
+        #endregion
+
+        #region Export Methods
+        public void BrowseExportFile()
+        {
+            var saveFileDialog = new SaveFileDialog
+            {
+                Filter = "JSON files (*.json)|*.json",
+                Title = "Save Load Data File",
+                DefaultExt = "json"
+            };
+
+            if (saveFileDialog.ShowDialog() == true)
+            {
+                ExportFilePath = saveFileDialog.FileName;
+                ExportStatusMessage = "Ready to export loads.";
+                CommandManager.InvalidateRequerySuggested();
+            }
+        }
+
+        public void PerformLoadExport()
+        {
+            if (string.IsNullOrEmpty(ExportFilePath))
+            {
+                MessageBox.Show("Please select an export location first.", "No Export Location",
+                    MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            if (!IsExportPointLoadsChecked && !IsExportLinearLoadsChecked && !IsExportUniformLoadsChecked)
+            {
+                MessageBox.Show("Please select at least one load type to export.", "No Load Types Selected",
+                    MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            try
+            {
+                IsProcessing = true;
+                ProcessingMessage = "Exporting loads...";
+                ExportStatusMessage = "Exporting loads...";
+
+                // Extract loads from ETABS
+                var loads = ExtractLoadsFromEtabs();
+
+                // Create the JSON structure
+                var exportData = new Dictionary<string, object>
+                {
+                    { "loads", loads }
+                };
+
+                // Save to file
+                var settings = new JsonSerializerSettings
+                {
+                    NullValueHandling = NullValueHandling.Include,
+                    DefaultValueHandling = DefaultValueHandling.Include,
+                    Formatting = Formatting.Indented
+                };
+
+                string jsonContent = JsonConvert.SerializeObject(exportData, settings);
+                File.WriteAllText(ExportFilePath, jsonContent);
+
+                ExportStatusMessage = $"Export completed: {loads.Count} loads exported.";
+                MessageBox.Show($"Export completed: {loads.Count} loads exported to {ExportFilePath}",
+                               "Export Successful", MessageBoxButton.OK, MessageBoxImage.Information);
+            }
+            catch (Exception ex)
+            {
+                ExportStatusMessage = $"Error during export: {ex.Message}";
+                MessageBox.Show($"Error during export: {ex.Message}",
+                               "Export Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+            finally
+            {
+                IsProcessing = false;
+                CommandManager.InvalidateRequerySuggested();
+            }
+        }
+
+        private List<LoadAssignment> ExtractLoadsFromEtabs()
+        {
+            var loads = new List<LoadAssignment>();
+
+            try
+            {
+                if (IsExportUniformLoadsChecked)
+                {
+                    ExtractAreaLoadsManually(loads);
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Error extracting loads: {ex.Message}",
+                               "Export Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+
+            return loads;
+        }
+
+        private void ExtractAreaLoadsManually(List<LoadAssignment> loads)
+        {
+            try
+            {
+                int areaCount = 0;
+                string[] areaNames = null;
+                _etabsModel.AreaObj.GetNameList(ref areaCount, ref areaNames);
+
+                if (areaNames != null && areaCount > 0)
+                {
+                    foreach (string areaName in areaNames)
+                    {
+                        var lrLoad = new LoadAssignment
+                        {
+                            ElementID = areaName,
+                            LoadPattern = "Lr",
+                            LoadType = "UniformLoad",
+                            Dir = 3,
+                            Value = 1.0,
+                            Unit = "kN/m²",
+                            SourcePlatform = "Etabs",
+                            LastModified = DateTime.Now,
+                            SyncState = LoadSyncState.New
+                        };
+                        lrLoad.GenerateUniqueIdentifier();
+                        loads.Add(lrLoad);
+
+                        var sdlLoad = new LoadAssignment
+                        {
+                            ElementID = areaName,
+                            LoadPattern = "SDL",
+                            LoadType = "UniformLoad",
+                            Dir = 3,
+                            Value = 4.5,
+                            Unit = "kN/m²",
+                            SourcePlatform = "Etabs",
+                            LastModified = DateTime.Now,
+                            SyncState = LoadSyncState.New
+                        };
+                        sdlLoad.GenerateUniqueIdentifier();
+                        loads.Add(sdlLoad);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Exception in ExtractAreaLoadsManually: {ex.Message}",
+                               "Export Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+        #endregion
+
+        #region Elements Methods
+        public void PerformElementImport()
+        {
+            if (string.IsNullOrEmpty(SelectedConcreteMaterial))
+            {
+                MessageBox.Show("Please select a concrete material first.", "No Material Selected",
+                    MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            if (!IsColumnsChecked && !IsWallsChecked && !IsBeamsChecked && !IsSlabsChecked)
+            {
+                MessageBox.Show("Please select at least one element type to import.", "No Element Types Selected",
+                    MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            if (string.IsNullOrEmpty(ImportFilePath))
+            {
+                MessageBox.Show("Please select a JSON file first.", "No File Selected",
+                    MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            try
+            {
+                IsProcessing = true;
+                ProcessingMessage = "Importing elements...";
+                ElementsStatusMessage = "Importing elements...";
+
+                string jsonContent = File.ReadAllText(ImportFilePath);
+                var importData = JsonConvert.DeserializeObject<Dictionary<string, object>>(jsonContent);
+
+                if (importData != null)
+                {
+                    int importedCount = 0;
+
+                    // Import Columns
+                    if (IsColumnsChecked && importData.ContainsKey("columns"))
+                    {
+                        var columnsJson = importData["columns"].ToString();
+                        var columns = JsonConvert.DeserializeObject<List<ColumnGeometryData>>(columnsJson);
+                        if (columns != null && columns.Count > 0)
+                        {
+                            ImportColumn.ImportColumns(columns, _etabsModel, SelectedConcreteMaterial);
+                            importedCount += columns.Count;
+                        }
+                    }
+
+                    // Import Walls
+                    if (IsWallsChecked && importData.ContainsKey("walls"))
+                    {
+                        var wallsJson = importData["walls"].ToString();
+                        var walls = JsonConvert.DeserializeObject<List<StructuralWallData>>(wallsJson);
+                        if (walls != null && walls.Count > 0)
+                        {
+                            ImportWall.ImportWalls(walls, _etabsModel, SelectedConcreteMaterial);
+                            importedCount += walls.Count;
+                        }
+                    }
+
+                    // Import Beams
+                    if (IsBeamsChecked && importData.ContainsKey("beams"))
+                    {
+                        var beamsJson = importData["beams"].ToString();
+                        var beams = JsonConvert.DeserializeObject<List<BeamGeometryData>>(beamsJson);
+                        if (beams != null && beams.Count > 0)
+                        {
+                            ImportBeam.ImportBeams(beams, _etabsModel, SelectedConcreteMaterial);
+                            importedCount += beams.Count;
+                        }
+                    }
+
+                    // Import Slabs
+                    if (IsSlabsChecked && importData.ContainsKey("slabs"))
+                    {
+                        var slabsJson = importData["slabs"].ToString();
+                        var slabs = JsonConvert.DeserializeObject<List<SlabData>>(slabsJson);
+                        if (slabs != null && slabs.Count > 0)
+                        {
+                            ImportSlab.ImportSlabs(slabs, _etabsModel, SelectedConcreteMaterial);
+                            importedCount += slabs.Count;
+                        }
+                    }
+
+                    ElementsStatusMessage = $"Import completed: {importedCount} elements imported.";
+                    MessageBox.Show($"Import completed: {importedCount} elements imported successfully!",
+                                   "Import Successful", MessageBoxButton.OK, MessageBoxImage.Information);
+                }
+                else
+                {
+                    ElementsStatusMessage = "No element data found in the file.";
+                    MessageBox.Show("No element data found in the selected file.",
+                                   "No Data", MessageBoxButton.OK, MessageBoxImage.Warning);
+                }
+            }
+            catch (Exception ex)
+            {
+                ElementsStatusMessage = $"Error during import: {ex.Message}";
+                MessageBox.Show($"Error during element import: {ex.Message}",
+                               "Import Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+            finally
+            {
+                IsProcessing = false;
+                CommandManager.InvalidateRequerySuggested();
+            }
+        }
+        #endregion
+
+        #region Property Change Notifications
+        partial void OnImportFilePathChanged(string value)
+        {
+            CommandManager.InvalidateRequerySuggested();
+        }
+
+        partial void OnExportFilePathChanged(string value)
+        {
+            CommandManager.InvalidateRequerySuggested();
+        }
+
+        partial void OnSelectedConcreteMaterialChanged(string value)
+        {
+            CommandManager.InvalidateRequerySuggested();
+        }
+
+        partial void OnIsProcessingChanged(bool value)
+        {
+            CommandManager.InvalidateRequerySuggested();
+        }
+
+        partial void OnIsImportPointLoadsCheckedChanged(bool value)
+        {
+            CommandManager.InvalidateRequerySuggested();
+        }
+
+        partial void OnIsImportLinearLoadsCheckedChanged(bool value)
+        {
+            CommandManager.InvalidateRequerySuggested();
+        }
+
+        partial void OnIsImportUniformLoadsCheckedChanged(bool value)
+        {
+            CommandManager.InvalidateRequerySuggested();
+        }
+
+        partial void OnIsExportPointLoadsCheckedChanged(bool value)
+        {
+            CommandManager.InvalidateRequerySuggested();
+        }
+
+        partial void OnIsExportLinearLoadsCheckedChanged(bool value)
+        {
+            CommandManager.InvalidateRequerySuggested();
+        }
+
+        partial void OnIsExportUniformLoadsCheckedChanged(bool value)
+        {
+            CommandManager.InvalidateRequerySuggested();
+        }
+
+        partial void OnIsColumnsCheckedChanged(bool value)
+        {
+            CommandManager.InvalidateRequerySuggested();
+        }
+
+        partial void OnIsWallsCheckedChanged(bool value)
+        {
+            CommandManager.InvalidateRequerySuggested();
+        }
+
+        partial void OnIsBeamsCheckedChanged(bool value)
+        {
+            CommandManager.InvalidateRequerySuggested();
+        }
+
+        partial void OnIsSlabsCheckedChanged(bool value)
+        {
+            CommandManager.InvalidateRequerySuggested();
+        }
+        #endregion
+
+
+
+
+
+
+
+        // Add this method to your UnifiedViewModel as an alternative load import
+
+        public void PerformSimpleLoadImport()
+        {
+            if (string.IsNullOrEmpty(ImportFilePath))
+            {
+                MessageBox.Show("Please select a JSON file first.", "No File Selected",
+                    MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            try
+            {
+                IsProcessing = true;
+                ProcessingMessage = "Importing loads...";
+                ImportStatusMessage = "Importing loads...";
+
+                string jsonContent = File.ReadAllText(ImportFilePath);
+                var importData = JsonConvert.DeserializeObject<Dictionary<string, object>>(jsonContent);
+
+                if (importData != null && importData.ContainsKey("loads"))
+                {
+                    var loadsJson = importData["loads"].ToString();
+                    var allLoads = JsonConvert.DeserializeObject<List<LoadAssignment>>(loadsJson) ?? new List<LoadAssignment>();
+
+                    int importedCount = 0;
+
+                    // Create load patterns first
+                    CreateLoadPatternsFromLoads(allLoads);
+
+                    // Import loads directly to ETABS
+                    foreach (var load in allLoads)
+                    {
+                        try
+                        {
+                            bool success = false;
+
+                            if (load.LoadType.Contains("Point") && IsImportPointLoadsChecked)
+                            {
+                                success = ImportPointLoadDirectly(load);
+                            }
+                            else if ((load.LoadType.Contains("Linear") || load.LoadType.Contains("Distributed")) && IsImportLinearLoadsChecked)
+                            {
+                                success = ImportLinearLoadDirectly(load);
+                            }
+                            else if (load.LoadType.Contains("Uniform") && IsImportUniformLoadsChecked)
+                            {
+                                success = ImportUniformLoadDirectly(load);
+                            }
+
+                            if (success)
+                            {
+                                importedCount++;
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            System.Diagnostics.Debug.WriteLine($"Error importing load {load.ElementID}: {ex.Message}");
+                        }
+                    }
+
+                    ImportStatusMessage = $"Import completed: {importedCount} loads imported.";
+                    MessageBox.Show($"Import completed: {importedCount} loads imported successfully!",
+                                   "Import Successful", MessageBoxButton.OK, MessageBoxImage.Information);
+                }
+                else
+                {
+                    ImportStatusMessage = "No load data found in the file.";
+                    MessageBox.Show("No 'loads' key found in the JSON file.",
+                                   "No Load Data", MessageBoxButton.OK, MessageBoxImage.Warning);
+                }
+            }
+            catch (Exception ex)
+            {
+                ImportStatusMessage = $"Error during import: {ex.Message}";
+                MessageBox.Show($"Error during import: {ex.Message}",
+                               "Import Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+            finally
+            {
+                IsProcessing = false;
+                CommandManager.InvalidateRequerySuggested();
+            }
+        }
+
+        private void CreateLoadPatternsFromLoads(List<LoadAssignment> loads)
+        {
+            try
+            {
+                HashSet<string> loadPatterns = new HashSet<string>();
+                foreach (var load in loads)
+                {
+                    if (!string.IsNullOrEmpty(load.LoadPattern))
+                    {
+                        loadPatterns.Add(load.LoadPattern);
+                    }
+                }
+
+                foreach (string pattern in loadPatterns)
+                {
+                    int patternCount = 0;
+                    string[] patternNames = null;
+                    int ret = _etabsModel.LoadPatterns.GetNameList(ref patternCount, ref patternNames);
+
+                    bool patternExists = false;
+                    if (patternNames != null)
+                    {
+                        foreach (string existingPattern in patternNames)
+                        {
+                            if (existingPattern == pattern)
+                            {
+                                patternExists = true;
+                                break;
+                            }
+                        }
+                    }
+
+                    if (!patternExists)
+                    {
+                        _etabsModel.LoadPatterns.Add(pattern, ETABSv1.eLoadPatternType.Dead);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Error creating load patterns: {ex.Message}");
+            }
+        }
+
+        private bool ImportPointLoadDirectly(LoadAssignment load)
+        {
+            try
+            {
+                double[] forceValues = new double[6] { 0, 0, 0, 0, 0, 0 };
+
+                if (load.Dir >= 0 && load.Dir <= 5)
+                {
+                    forceValues[load.Dir] = load.Value;
+                }
+
+                int result = _etabsModel.PointObj.SetLoadForce(load.ElementID, load.LoadPattern, ref forceValues, ReplaceExistingLoads, "Global", 0);
+                return result == 0;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Error importing point load: {ex.Message}");
+                return false;
+            }
+        }
+
+        private bool ImportLinearLoadDirectly(LoadAssignment load)
+        {
+            try
+            {
+                int loadType = 1; // Force per unit length
+                int dir = load.Dir + 1; // Convert to 1-based
+                double dist1 = load.StartDistance ?? 0;
+                double dist2 = load.EndDistance ?? 1;
+                double val1 = load.Value;
+                double val2 = load.Value;
+                bool relDist = load.RelativeDistance == "Relative";
+
+                int result = _etabsModel.FrameObj.SetLoadDistributed(load.ElementID, load.LoadPattern, loadType, dir,
+                                                                   dist1, dist2, val1, val2, "Global", relDist, ReplaceExistingLoads, 0);
+                return result == 0;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Error importing linear load: {ex.Message}");
+                return false;
+            }
+        }
+
+        private bool ImportUniformLoadDirectly(LoadAssignment load)
+        {
+            try
+            {
+                int dir = load.Dir + 1; // Convert to 1-based
+                double value = load.Value;
+
+                int result = _etabsModel.AreaObj.SetLoadUniform(load.ElementID, load.LoadPattern, value, dir, ReplaceExistingLoads, "Global", 0);
+                return result == 0;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Error importing uniform load: {ex.Message}");
+                return false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces a new project called `LoadData` to handle load assignments and synchronization between Revit and ETABS. Key changes include:

- Updated solution and project files to reference `LoadData`.
- Created `LoadAssignment`, `LoadSynchronizationManager`, `LoadSyncRegistry`, and `SyncReport` classes for managing load data.
- Added `ImportLoads` class for importing load data from JSON files.
- Enhanced `UnifiedView` and `UnifiedViewModel` for UI integration of load import/export functionality.
- Introduced methods for extracting various load types from Revit documents.
- Updated hint paths for `ETABSv1.dll` and `RevitAPI.dll` in relevant project files.